### PR TITLE
feat: add editable export keyboard mapping preview

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -48,6 +48,8 @@ In the **Export** tab:
 - Review warnings and errors
 - Download `karabiner.json`
 - Copy formatted JSON to clipboard
+- Inspect mappings on a visual keyboard (click a key to see all matching simple,
+  fn, and complex mappings)
 
 Export is blocked while validation contains severity `error`.
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,8 @@ import {
   Moon,
   Sun,
   Upload,
-  Download,
-  Copy,
   FileJson,
   CheckCircle2,
-  AlertCircle,
   FilePlus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -21,11 +18,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { Toaster } from '@/components/ui/toaster';
 import { ProfileManager } from '@/components/profile/profile-manager';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import type { KarabinerConfig } from '@/types/karabiner';
 import { validateConfig, type ValidationError } from '@/lib/validation';
 import { createMinimalKarabinerConfig } from '@/lib/default-config';
+import { ExportPanel } from '@/components/export/export-panel';
 
 export default function KarabinerEditor() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
@@ -278,74 +274,16 @@ export default function KarabinerEditor() {
             )}
           </TabsContent>
 
-          <TabsContent value='export' className='space-y-6'>
-            {validationErrors.length > 0 && (
-              <Card className='p-4'>
-                <h3 className='font-semibold mb-3 flex items-center gap-2'>
-                  <AlertCircle className='h-5 w-5 text-yellow-600 dark:text-yellow-500' />
-                  Validation Issues ({validationErrors.length})
-                </h3>
-                <ScrollArea className='max-h-[300px]'>
-                  <div className='space-y-2'>
-                    {validationErrors.map((error, index) => (
-                      <Alert
-                        key={index}
-                        variant={
-                          error.severity === 'error' ? 'destructive' : 'default'
-                        }
-                        className={
-                          error.severity === 'warning'
-                            ? 'border-yellow-500 dark:border-yellow-600'
-                            : ''
-                        }
-                      >
-                        <AlertCircle className='h-4 w-4' />
-                        <AlertTitle className='text-sm font-medium'>
-                          {error.severity === 'error' ? 'Error' : 'Warning'}:{' '}
-                          {error.path}
-                        </AlertTitle>
-                        <AlertDescription className='text-xs'>
-                          {error.message}
-                        </AlertDescription>
-                      </Alert>
-                    ))}
-                  </div>
-                </ScrollArea>
-              </Card>
-            )}
-
-            <Card className='p-6'>
-              <h2 className='text-lg font-semibold mb-4'>Export Config</h2>
-              <div className='flex gap-4'>
-                <Button
-                  onClick={handleExport}
-                  disabled={validationErrors.some(
-                    (e) => e.severity === 'error',
-                  )}
-                >
-                  <Download className='mr-2 h-4 w-4' />
-                  Download JSON
-                </Button>
-                <Button onClick={handleCopy} variant='outline'>
-                  <Copy className='mr-2 h-4 w-4' />
-                  Copy to Clipboard
-                </Button>
-              </div>
-              {validationErrors.some((e) => e.severity === 'error') && (
-                <p className='text-sm text-destructive mt-2'>
-                  Fix all errors before exporting
-                </p>
-              )}
-            </Card>
-
-            <Card className='p-6'>
-              <h2 className='text-lg font-semibold mb-4'>Preview</h2>
-              <Textarea
-                value={config ? JSON.stringify(config, null, 2) : ''}
-                readOnly
-                className='font-mono text-sm min-h-[400px]'
+          <TabsContent value='export'>
+            {config && (
+              <ExportPanel
+                config={config}
+                validationErrors={validationErrors}
+                onExport={handleExport}
+                onCopy={handleCopy}
+                onConfigChange={updateConfig}
               />
-            </Card>
+            )}
           </TabsContent>
         </Tabs>
       </main>

--- a/src/components/export/export-keyboard-preview.tsx
+++ b/src/components/export/export-keyboard-preview.tsx
@@ -1,0 +1,490 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { ArrowRight, ChevronDown, ChevronUp } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Textarea } from '@/components/ui/textarea';
+import { KeyboardShell } from '@/components/keyboard/keyboard-shell';
+import { useKeyboardLayout } from '@/components/keyboard/keyboard-layout-context';
+import { useToast } from '@/hooks/use-toast';
+import {
+  getMappingValue,
+  updateMappingValue,
+} from '@/lib/mapping-entry-access';
+import { buildMappingIndex } from '@/lib/mapping-index';
+import {
+  formatTargetSummary,
+  normalizeConfigMappings,
+  type NormalizedMappingEntry,
+  type NormalizedMappingType,
+} from '@/lib/mapping-normalizer';
+import { getKeyLabel, toKarabinerKeyCode } from '@/lib/keyboard-layout';
+import { cn } from '@/lib/utils';
+import type { KarabinerConfig } from '@/types/karabiner';
+
+type MappingDirectionFilter = 'both' | 'from' | 'to';
+type MappingTypeFilter = 'all' | NormalizedMappingType;
+type MappingScopeFilter = 'all' | 'profile' | 'device';
+
+interface ExportKeyboardPreviewProps {
+  config: KarabinerConfig;
+  onConfigChange: (next: KarabinerConfig) => void;
+}
+
+export function ExportKeyboardPreview({
+  config,
+  onConfigChange,
+}: ExportKeyboardPreviewProps) {
+  const { toast } = useToast();
+  const { layoutType, setLayoutType } = useKeyboardLayout();
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [directionFilter, setDirectionFilter] =
+    useState<MappingDirectionFilter>('both');
+  const [typeFilter, setTypeFilter] = useState<MappingTypeFilter>('all');
+  const [scopeFilter, setScopeFilter] = useState<MappingScopeFilter>('all');
+  const [showFilters, setShowFilters] = useState(false);
+  const [editingEntry, setEditingEntry] =
+    useState<NormalizedMappingEntry | null>(null);
+  const [editorValue, setEditorValue] = useState('');
+
+  const entries = useMemo(() => normalizeConfigMappings(config), [config]);
+  const mappingIndex = useMemo(() => buildMappingIndex(entries), [entries]);
+
+  const selectedFromEntries = useMemo(() => {
+    if (!selectedKey) {
+      return [];
+    }
+    return applyFilters(mappingIndex.byFromKey.get(selectedKey) || [], {
+      typeFilter,
+      scopeFilter,
+    });
+  }, [mappingIndex.byFromKey, scopeFilter, selectedKey, typeFilter]);
+
+  const selectedToEntries = useMemo(() => {
+    if (!selectedKey) {
+      return [];
+    }
+    return applyFilters(mappingIndex.byToKey.get(selectedKey) || [], {
+      typeFilter,
+      scopeFilter,
+    });
+  }, [mappingIndex.byToKey, scopeFilter, selectedKey, typeFilter]);
+
+  const handleKeyPress = useCallback((button: string) => {
+    setSelectedKey(toKarabinerKeyCode(button));
+  }, []);
+
+  const handleOpenEditor = useCallback(
+    (entry: NormalizedMappingEntry) => {
+      const value = getMappingValue(config, entry);
+      if (!value) {
+        toast({
+          title: 'Unable to open mapping',
+          description: 'Mapping path could not be resolved.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      setEditingEntry(entry);
+      setEditorValue(JSON.stringify(value, null, 2));
+    },
+    [config, toast],
+  );
+
+  const handleSaveEditor = useCallback(() => {
+    if (!editingEntry) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(editorValue);
+      const updated = updateMappingValue(config, editingEntry, parsed);
+      if (!updated) {
+        toast({
+          title: 'Unable to update mapping',
+          description: 'Mapping path could not be resolved.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      onConfigChange(updated);
+      setEditingEntry(null);
+      setEditorValue('');
+      toast({
+        title: 'Mapping updated',
+        description: 'Changes were applied to the configuration.',
+      });
+    } catch {
+      toast({
+        title: 'Invalid JSON',
+        description: 'Please provide valid JSON for this mapping.',
+        variant: 'destructive',
+      });
+    }
+  }, [config, editingEntry, editorValue, onConfigChange, toast]);
+
+  const handleCloseEditor = useCallback(() => {
+    setEditingEntry(null);
+    setEditorValue('');
+  }, []);
+
+  const selectedHighlight = selectedKey ? [selectedKey] : [];
+  const highlightLayers = [
+    { className: 'kb-mapped', keys: Array.from(mappingIndex.mappedKeys) },
+    { className: 'kb-selected', keys: selectedHighlight },
+  ];
+
+  const showFrom = directionFilter === 'both' || directionFilter === 'from';
+  const showTo = directionFilter === 'both' || directionFilter === 'to';
+
+  const legend = (
+    <div className='flex items-center gap-3 text-xs text-muted-foreground'>
+      <div className='flex items-center gap-1'>
+        <div className='w-2.5 h-2.5 rounded-sm bg-primary/20 border border-primary' />
+        <span>Has mappings</span>
+      </div>
+      {selectedKey && (
+        <div className='flex items-center gap-1'>
+          <div className='w-2.5 h-2.5 rounded-sm bg-primary/40 border border-primary' />
+          <span>Selected key</span>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className='grid gap-4 xl:grid-cols-[1.4fr_1fr]'>
+      <div className='space-y-3'>
+        <KeyboardShell
+          layoutType={layoutType}
+          onLayoutChange={(value) => setLayoutType(value)}
+          legend={legend}
+          keyboardBaseClass='export-kb'
+          highlightLayers={highlightLayers}
+          onKeyPress={handleKeyPress}
+          physicalKeyboardHighlight={false}
+        />
+      </div>
+
+      <div className='rounded-lg border p-3 bg-card'>
+        <div className='flex items-center justify-between gap-2 mb-3'>
+          <h3 className='text-sm font-semibold'>Key Mapping Details</h3>
+          <Button
+            type='button'
+            size='sm'
+            variant='outline'
+            className='h-7 px-2 text-xs cursor-pointer'
+            onClick={() => setShowFilters((prev) => !prev)}
+          >
+            {showFilters ? 'Hide Filters' : 'Show Filters'}
+            {showFilters ? (
+              <ChevronUp className='ml-1 h-3.5 w-3.5' />
+            ) : (
+              <ChevronDown className='ml-1 h-3.5 w-3.5' />
+            )}
+          </Button>
+        </div>
+
+        {showFilters && (
+          <div className='flex flex-wrap gap-2 mb-3'>
+            <FilterPillGroup
+              label='Direction'
+              options={[
+                { value: 'both', label: 'Both' },
+                { value: 'from', label: 'From' },
+                { value: 'to', label: 'To' },
+              ]}
+              value={directionFilter}
+              onChange={(value) =>
+                setDirectionFilter(value as MappingDirectionFilter)
+              }
+            />
+            <FilterPillGroup
+              label='Type'
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'simple', label: 'Simple' },
+                { value: 'fn', label: 'Fn' },
+                { value: 'complex', label: 'Complex' },
+              ]}
+              value={typeFilter}
+              onChange={(value) => setTypeFilter(value as MappingTypeFilter)}
+            />
+            <FilterPillGroup
+              label='Scope'
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'profile', label: 'Profile' },
+                { value: 'device', label: 'Device' },
+              ]}
+              value={scopeFilter}
+              onChange={(value) => setScopeFilter(value as MappingScopeFilter)}
+            />
+          </div>
+        )}
+
+        {!selectedKey ? (
+          <div className='rounded-lg border border-dashed px-3 py-8 text-center text-sm text-muted-foreground'>
+            Select a key on the keyboard to review mappings.
+          </div>
+        ) : (
+          <ScrollArea className='h-[420px] pr-2'>
+            <div className='space-y-4'>
+              {showFrom && (
+                <MappingSection
+                  title='From this key'
+                  entries={selectedFromEntries}
+                  selectedKey={selectedKey}
+                  mode='from'
+                  onItemClick={handleOpenEditor}
+                />
+              )}
+
+              {showTo && (
+                <MappingSection
+                  title='Maps to this key'
+                  entries={selectedToEntries}
+                  selectedKey={selectedKey}
+                  mode='to'
+                  onItemClick={handleOpenEditor}
+                />
+              )}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+
+      <Dialog
+        open={Boolean(editingEntry)}
+        onOpenChange={(open) => !open && handleCloseEditor()}
+      >
+        <DialogContent className='sm:max-w-2xl'>
+          <DialogHeader>
+            <DialogTitle>Edit Mapping JSON</DialogTitle>
+          </DialogHeader>
+          <div className='space-y-3'>
+            {editingEntry && (
+              <p className='text-xs text-muted-foreground'>
+                {editingEntry.type.toUpperCase()} - {editingEntry.profileName}
+                {editingEntry.scope === 'device' && editingEntry.deviceLabel
+                  ? ` - ${editingEntry.deviceLabel}`
+                  : ''}
+                {editingEntry.ruleDescription
+                  ? ` - ${editingEntry.ruleDescription}`
+                  : ''}
+              </p>
+            )}
+            <Textarea
+              value={editorValue}
+              onChange={(event) => setEditorValue(event.target.value)}
+              className='font-mono text-xs min-h-[320px]'
+            />
+          </div>
+          <DialogFooter>
+            <Button variant='outline' onClick={handleCloseEditor}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveEditor}>Save Mapping</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function applyFilters(
+  entries: NormalizedMappingEntry[],
+  filters: {
+    typeFilter: MappingTypeFilter;
+    scopeFilter: MappingScopeFilter;
+  },
+): NormalizedMappingEntry[] {
+  return entries.filter((entry) => {
+    const typeMatches =
+      filters.typeFilter === 'all' || entry.type === filters.typeFilter;
+    const scopeMatches =
+      filters.scopeFilter === 'all' || entry.scope === filters.scopeFilter;
+    return typeMatches && scopeMatches;
+  });
+}
+
+function MappingSection({
+  title,
+  entries,
+  selectedKey,
+  mode,
+  onItemClick,
+}: {
+  title: string;
+  entries: NormalizedMappingEntry[];
+  selectedKey: string;
+  mode: 'from' | 'to';
+  onItemClick: (entry: NormalizedMappingEntry) => void;
+}) {
+  return (
+    <section className='space-y-2'>
+      <div className='flex items-center justify-between'>
+        <h4 className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+          {title}
+        </h4>
+        <span className='text-xs text-muted-foreground'>
+          {entries.length} result{entries.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+          No mappings in this view.
+        </div>
+      ) : (
+        <div className='space-y-2'>
+          {entries.map((entry) => (
+            <MappingItem
+              key={`${mode}-${entry.id}`}
+              entry={entry}
+              selectedKey={selectedKey}
+              mode={mode}
+              onClick={() => onItemClick(entry)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MappingItem({
+  entry,
+  selectedKey,
+  mode,
+  onClick,
+}: {
+  entry: NormalizedMappingEntry;
+  selectedKey: string;
+  mode: 'from' | 'to';
+  onClick: () => void;
+}) {
+  const directionInfo =
+    mode === 'from'
+      ? formatTargetSummary(entry)
+      : formatToMatchSummary(entry, selectedKey);
+
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className='w-full text-left rounded-md border p-3 space-y-2 hover:bg-muted/40 transition-colors cursor-pointer'
+    >
+      <div className='flex flex-wrap items-center gap-1.5'>
+        <Badge
+          variant='secondary'
+          className={cn(
+            'text-[10px] uppercase tracking-wide',
+            entry.type === 'simple' && 'bg-blue-500/10 text-blue-700',
+            entry.type === 'fn' && 'bg-amber-500/10 text-amber-700',
+            entry.type === 'complex' && 'bg-violet-500/10 text-violet-700',
+          )}
+        >
+          {entry.type}
+        </Badge>
+        <Badge variant='outline' className='text-[10px]'>
+          {entry.profileName}
+        </Badge>
+        <Badge variant='outline' className='text-[10px]'>
+          {entry.scope === 'profile'
+            ? 'All devices'
+            : entry.deviceLabel || `Device ${(entry.deviceIndex ?? 0) + 1}`}
+        </Badge>
+        {entry.ruleDescription && (
+          <Badge variant='outline' className='text-[10px]'>
+            {entry.ruleDescription}
+          </Badge>
+        )}
+      </div>
+
+      <div className='text-sm flex items-center gap-2'>
+        <code className='rounded bg-muted px-1.5 py-0.5 font-mono'>
+          {getKeyLabel(entry.fromKey)}
+        </code>
+        <ArrowRight className='h-3.5 w-3.5 text-muted-foreground' />
+        <span className='text-muted-foreground'>{directionInfo || '-'}</span>
+      </div>
+
+      <div className='flex flex-wrap items-center gap-1.5'>
+        {entry.fromModifiers.length > 0 && (
+          <Badge variant='outline' className='text-[10px]'>
+            From mods: {entry.fromModifiers.join(' + ')}
+          </Badge>
+        )}
+        {entry.conditionsCount > 0 && (
+          <Badge variant='outline' className='text-[10px]'>
+            {entry.conditionsCount} condition
+            {entry.conditionsCount > 1 ? 's' : ''}
+          </Badge>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function formatComplexPhase(phase: string): string {
+  if (phase === 'default' || phase === 'to') {
+    return 'to';
+  }
+  return phase.replace(/_/g, ' ');
+}
+
+function formatToMatchSummary(
+  entry: NormalizedMappingEntry,
+  selectedKey: string,
+): string {
+  const phases = entry.toTargets
+    .filter((target) => target.key === selectedKey)
+    .map((target) => formatComplexPhase(target.phase));
+
+  const phaseText = phases.length > 0 ? ` via ${phases.join(', ')}` : '';
+  return `${getKeyLabel(selectedKey)}${phaseText}`;
+}
+
+function FilterPillGroup({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className='flex items-center gap-1'>
+      <span className='text-xs text-muted-foreground'>{label}</span>
+      <div className='inline-flex items-center rounded-md border bg-background p-0.5'>
+        {options.map((option) => (
+          <Button
+            key={option.value}
+            type='button'
+            size='sm'
+            variant={value === option.value ? 'secondary' : 'ghost'}
+            className='h-6 px-2 text-xs'
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/export/export-panel.tsx
+++ b/src/components/export/export-panel.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { AlertCircle, Copy, Download } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Card } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { KeyboardLayoutProvider } from '@/components/keyboard/keyboard-layout-context';
+import { ExportKeyboardPreview } from '@/components/export/export-keyboard-preview';
+import type { ValidationError } from '@/lib/validation';
+import type { KarabinerConfig } from '@/types/karabiner';
+
+interface ExportPanelProps {
+  config: KarabinerConfig;
+  validationErrors: ValidationError[];
+  onExport: () => void;
+  onCopy: () => void;
+  onConfigChange: (next: KarabinerConfig) => void;
+}
+
+export function ExportPanel({
+  config,
+  validationErrors,
+  onExport,
+  onCopy,
+  onConfigChange,
+}: ExportPanelProps) {
+  const hasCriticalErrors = validationErrors.some(
+    (e) => e.severity === 'error',
+  );
+
+  return (
+    <div className='space-y-6'>
+      {validationErrors.length > 0 && (
+        <Card className='p-4'>
+          <h3 className='font-semibold mb-3 flex items-center gap-2'>
+            <AlertCircle className='h-5 w-5 text-yellow-600 dark:text-yellow-500' />
+            Validation Issues ({validationErrors.length})
+          </h3>
+          <ScrollArea className='max-h-[300px]'>
+            <div className='space-y-2'>
+              {validationErrors.map((error, index) => (
+                <Alert
+                  key={index}
+                  variant={
+                    error.severity === 'error' ? 'destructive' : 'default'
+                  }
+                  className={
+                    error.severity === 'warning'
+                      ? 'border-yellow-500 dark:border-yellow-600'
+                      : ''
+                  }
+                >
+                  <AlertCircle className='h-4 w-4' />
+                  <AlertTitle className='text-sm font-medium'>
+                    {error.severity === 'error' ? 'Error' : 'Warning'}:{' '}
+                    {error.path}
+                  </AlertTitle>
+                  <AlertDescription className='text-xs'>
+                    {error.message}
+                  </AlertDescription>
+                </Alert>
+              ))}
+            </div>
+          </ScrollArea>
+        </Card>
+      )}
+
+      <Card className='p-6'>
+        <h2 className='text-lg font-semibold mb-4'>Export Config</h2>
+        <div className='flex gap-4'>
+          <Button onClick={onExport} disabled={hasCriticalErrors}>
+            <Download className='mr-2 h-4 w-4' />
+            Download JSON
+          </Button>
+          <Button onClick={onCopy} variant='outline'>
+            <Copy className='mr-2 h-4 w-4' />
+            Copy to Clipboard
+          </Button>
+        </div>
+        {hasCriticalErrors && (
+          <p className='text-sm text-destructive mt-2'>
+            Fix all errors before exporting
+          </p>
+        )}
+      </Card>
+
+      <Card className='p-6'>
+        <h2 className='text-lg font-semibold mb-4'>Keyboard Mapping Preview</h2>
+        <KeyboardLayoutProvider>
+          <ExportKeyboardPreview
+            config={config}
+            onConfigChange={onConfigChange}
+          />
+        </KeyboardLayoutProvider>
+      </Card>
+
+      <Card className='p-6'>
+        <h2 className='text-lg font-semibold mb-4'>Preview</h2>
+        <Textarea
+          value={JSON.stringify(config, null, 2)}
+          readOnly
+          className='font-mono text-sm min-h-[400px]'
+        />
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/mapping-entry-access.ts
+++ b/src/lib/mapping-entry-access.ts
@@ -1,0 +1,114 @@
+import type { Manipulator } from '@/types/karabiner';
+import type {
+  KarabinerConfig,
+  SimpleModification,
+  FnFunctionKey,
+} from '@/types/karabiner';
+import type { NormalizedMappingEntry } from '@/lib/mapping-normalizer';
+
+export type EditableMappingValue =
+  | SimpleModification
+  | FnFunctionKey
+  | Manipulator;
+
+export function getMappingValue(
+  config: KarabinerConfig,
+  entry: NormalizedMappingEntry,
+): EditableMappingValue | null {
+  const profile = config.profiles[entry.profileIndex];
+  if (!profile) {
+    return null;
+  }
+
+  if (entry.type === 'complex') {
+    const rule = profile.complex_modifications?.rules?.[entry.ruleIndex ?? -1];
+    return rule?.manipulators?.[entry.manipulatorIndex ?? -1] ?? null;
+  }
+
+  const mappingIndex = entry.mappingIndex ?? -1;
+  if (mappingIndex < 0) {
+    return null;
+  }
+
+  if (entry.scope === 'profile') {
+    const list =
+      entry.type === 'simple'
+        ? profile.simple_modifications
+        : profile.fn_function_keys;
+    return list?.[mappingIndex] ?? null;
+  }
+
+  const device = profile.devices?.[entry.deviceIndex ?? -1];
+  if (!device) {
+    return null;
+  }
+
+  const list =
+    entry.type === 'simple'
+      ? device.simple_modifications
+      : device.fn_function_keys;
+  return list?.[mappingIndex] ?? null;
+}
+
+export function updateMappingValue(
+  config: KarabinerConfig,
+  entry: NormalizedMappingEntry,
+  value: EditableMappingValue,
+): KarabinerConfig | null {
+  const next = structuredClone(config);
+  const profile = next.profiles[entry.profileIndex];
+
+  if (!profile) {
+    return null;
+  }
+
+  if (entry.type === 'complex') {
+    const rule = profile.complex_modifications?.rules?.[entry.ruleIndex ?? -1];
+    const manipulatorIndex = entry.manipulatorIndex ?? -1;
+    if (!rule || manipulatorIndex < 0 || !rule.manipulators[manipulatorIndex]) {
+      return null;
+    }
+    rule.manipulators[manipulatorIndex] = value as Manipulator;
+    return next;
+  }
+
+  const mappingIndex = entry.mappingIndex ?? -1;
+  if (mappingIndex < 0) {
+    return null;
+  }
+
+  if (entry.scope === 'profile') {
+    if (entry.type === 'simple') {
+      if (!profile.simple_modifications?.[mappingIndex]) {
+        return null;
+      }
+      profile.simple_modifications[mappingIndex] = value as SimpleModification;
+      return next;
+    }
+
+    if (!profile.fn_function_keys?.[mappingIndex]) {
+      return null;
+    }
+    profile.fn_function_keys[mappingIndex] = value as FnFunctionKey;
+    return next;
+  }
+
+  const device = profile.devices?.[entry.deviceIndex ?? -1];
+  if (!device) {
+    return null;
+  }
+
+  if (entry.type === 'simple') {
+    if (!device.simple_modifications?.[mappingIndex]) {
+      return null;
+    }
+    device.simple_modifications[mappingIndex] = value as SimpleModification;
+    return next;
+  }
+
+  if (!device.fn_function_keys?.[mappingIndex]) {
+    return null;
+  }
+  device.fn_function_keys[mappingIndex] = value as FnFunctionKey;
+  return next;
+}

--- a/src/lib/mapping-index.ts
+++ b/src/lib/mapping-index.ts
@@ -1,0 +1,42 @@
+import type { NormalizedMappingEntry } from '@/lib/mapping-normalizer';
+
+export interface MappingIndex {
+  byFromKey: Map<string, NormalizedMappingEntry[]>;
+  byToKey: Map<string, NormalizedMappingEntry[]>;
+  mappedKeys: Set<string>;
+}
+
+export function buildMappingIndex(
+  entries: NormalizedMappingEntry[],
+): MappingIndex {
+  const byFromKey = new Map<string, NormalizedMappingEntry[]>();
+  const byToKey = new Map<string, NormalizedMappingEntry[]>();
+  const toDedup = new Map<string, Set<string>>();
+  const mappedKeys = new Set<string>();
+
+  entries.forEach((entry) => {
+    if (entry.fromKey) {
+      mappedKeys.add(entry.fromKey);
+      const fromEntries = byFromKey.get(entry.fromKey) || [];
+      fromEntries.push(entry);
+      byFromKey.set(entry.fromKey, fromEntries);
+    }
+
+    entry.toTargets.forEach((target) => {
+      mappedKeys.add(target.key);
+
+      const seenForKey = toDedup.get(target.key) || new Set<string>();
+      if (seenForKey.has(entry.id)) {
+        return;
+      }
+      seenForKey.add(entry.id);
+      toDedup.set(target.key, seenForKey);
+
+      const toEntries = byToKey.get(target.key) || [];
+      toEntries.push(entry);
+      byToKey.set(target.key, toEntries);
+    });
+  });
+
+  return { byFromKey, byToKey, mappedKeys };
+}

--- a/src/lib/mapping-normalizer.ts
+++ b/src/lib/mapping-normalizer.ts
@@ -1,0 +1,306 @@
+import { getKeyLabel } from '@/lib/keyboard-layout';
+import type {
+  Device,
+  FnFunctionKey,
+  KarabinerConfig,
+  KeyCode,
+  Manipulator,
+  Profile,
+  ToEvent,
+} from '@/types/karabiner';
+
+export type NormalizedMappingType = 'simple' | 'fn' | 'complex';
+export type MappingScope = 'profile' | 'device';
+export type ComplexTargetPhase =
+  | 'to'
+  | 'to_if_alone'
+  | 'to_if_held_down'
+  | 'to_after_key_up';
+
+export interface NormalizedTarget {
+  key: string;
+  phase: ComplexTargetPhase | 'default';
+  modifiers: string[];
+}
+
+export interface NormalizedMappingEntry {
+  id: string;
+  type: NormalizedMappingType;
+  scope: MappingScope;
+  profileIndex: number;
+  profileName: string;
+  mappingIndex?: number;
+  deviceIndex?: number;
+  deviceLabel?: string;
+  fromKey: string;
+  fromModifiers: string[];
+  toTargets: NormalizedTarget[];
+  conditionsCount: number;
+  ruleIndex?: number;
+  ruleDescription?: string;
+  manipulatorIndex?: number;
+}
+
+export function normalizeConfigMappings(
+  config: KarabinerConfig,
+): NormalizedMappingEntry[] {
+  const entries: NormalizedMappingEntry[] = [];
+
+  config.profiles.forEach((profile, profileIndex) => {
+    const profileName = profile.name || `Profile ${profileIndex + 1}`;
+
+    collectSimpleMappings(entries, profile, profileIndex, profileName);
+    collectFnMappings(entries, profile, profileIndex, profileName);
+    collectComplexMappings(entries, profile, profileIndex, profileName);
+  });
+
+  return entries;
+}
+
+function collectSimpleMappings(
+  entries: NormalizedMappingEntry[],
+  profile: Profile,
+  profileIndex: number,
+  profileName: string,
+) {
+  profile.simple_modifications?.forEach((mapping, mappingIndex) => {
+    const entry = buildSimpleLikeEntry({
+      type: 'simple',
+      id: `p-${profileIndex}-simple-${mappingIndex}`,
+      mapping,
+      mappingIndex,
+      profileIndex,
+      profileName,
+      scope: 'profile',
+    });
+    if (entry) {
+      entries.push(entry);
+    }
+  });
+
+  profile.devices?.forEach((device, deviceIndex) => {
+    const deviceLabel = formatDeviceLabel(device, deviceIndex);
+    device.simple_modifications?.forEach((mapping, mappingIndex) => {
+      const entry = buildSimpleLikeEntry({
+        type: 'simple',
+        id: `p-${profileIndex}-d-${deviceIndex}-simple-${mappingIndex}`,
+        mapping,
+        mappingIndex,
+        profileIndex,
+        profileName,
+        scope: 'device',
+        deviceIndex,
+        deviceLabel,
+      });
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  });
+}
+
+function collectFnMappings(
+  entries: NormalizedMappingEntry[],
+  profile: Profile,
+  profileIndex: number,
+  profileName: string,
+) {
+  profile.fn_function_keys?.forEach((mapping, mappingIndex) => {
+    const entry = buildSimpleLikeEntry({
+      type: 'fn',
+      id: `p-${profileIndex}-fn-${mappingIndex}`,
+      mapping,
+      mappingIndex,
+      profileIndex,
+      profileName,
+      scope: 'profile',
+    });
+    if (entry) {
+      entries.push(entry);
+    }
+  });
+
+  profile.devices?.forEach((device, deviceIndex) => {
+    const deviceLabel = formatDeviceLabel(device, deviceIndex);
+    device.fn_function_keys?.forEach((mapping, mappingIndex) => {
+      const entry = buildSimpleLikeEntry({
+        type: 'fn',
+        id: `p-${profileIndex}-d-${deviceIndex}-fn-${mappingIndex}`,
+        mapping,
+        mappingIndex,
+        profileIndex,
+        profileName,
+        scope: 'device',
+        deviceIndex,
+        deviceLabel,
+      });
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  });
+}
+
+function collectComplexMappings(
+  entries: NormalizedMappingEntry[],
+  profile: Profile,
+  profileIndex: number,
+  profileName: string,
+) {
+  profile.complex_modifications?.rules?.forEach((rule, ruleIndex) => {
+    rule.manipulators.forEach((manipulator, manipulatorIndex) => {
+      const fromKey = pickKey(manipulator.from);
+      if (!fromKey) {
+        return;
+      }
+
+      entries.push({
+        id: `p-${profileIndex}-rule-${ruleIndex}-m-${manipulatorIndex}`,
+        type: 'complex',
+        scope: 'profile',
+        profileIndex,
+        profileName,
+        fromKey,
+        fromModifiers: normalizeModifiers(
+          manipulator.from.modifiers?.mandatory,
+        ),
+        toTargets: collectComplexTargets(manipulator),
+        conditionsCount: manipulator.conditions?.length || 0,
+        ruleIndex,
+        ruleDescription: rule.description || `Rule ${ruleIndex + 1}`,
+        manipulatorIndex,
+      });
+    });
+  });
+}
+
+function buildSimpleLikeEntry({
+  type,
+  id,
+  mapping,
+  mappingIndex,
+  profileIndex,
+  profileName,
+  scope,
+  deviceIndex,
+  deviceLabel,
+}: {
+  type: 'simple' | 'fn';
+  id: string;
+  mapping: FnFunctionKey;
+  mappingIndex: number;
+  profileIndex: number;
+  profileName: string;
+  scope: MappingScope;
+  deviceIndex?: number;
+  deviceLabel?: string;
+}): NormalizedMappingEntry | null {
+  const fromKey = pickKey(mapping.from);
+  if (!fromKey) {
+    return null;
+  }
+
+  const toValues = Array.isArray(mapping.to) ? mapping.to : [mapping.to];
+  const toTargets = toValues
+    .map((value) => pickKey(value))
+    .filter(Boolean)
+    .map((key) => ({ key, phase: 'default' as const, modifiers: [] }));
+
+  return {
+    id,
+    type,
+    scope,
+    profileIndex,
+    profileName,
+    mappingIndex,
+    deviceIndex,
+    deviceLabel,
+    fromKey,
+    fromModifiers: [],
+    toTargets,
+    conditionsCount: 0,
+  };
+}
+
+function collectComplexTargets(manipulator: Manipulator): NormalizedTarget[] {
+  const targets: NormalizedTarget[] = [];
+
+  appendTargets(targets, manipulator.to, 'to');
+  appendTargets(targets, manipulator.to_if_alone, 'to_if_alone');
+  appendTargets(targets, manipulator.to_if_held_down, 'to_if_held_down');
+  appendTargets(targets, manipulator.to_after_key_up, 'to_after_key_up');
+
+  return targets;
+}
+
+function appendTargets(
+  targets: NormalizedTarget[],
+  events: ToEvent[] | undefined,
+  phase: ComplexTargetPhase,
+) {
+  events?.forEach((event) => {
+    const key = pickKey(event);
+    if (!key) {
+      return;
+    }
+
+    targets.push({
+      key,
+      phase,
+      modifiers: normalizeModifiers(event.modifiers),
+    });
+  });
+}
+
+function pickKey(value?: KeyCode | ToEvent | null): string {
+  if (!value) {
+    return '';
+  }
+  return (
+    value.key_code || value.consumer_key_code || value.pointing_button || ''
+  );
+}
+
+function normalizeModifiers(modifiers: string[] | undefined): string[] {
+  if (!modifiers || modifiers.length === 0) {
+    return [];
+  }
+  return Array.from(new Set(modifiers)).sort();
+}
+
+function formatDeviceLabel(device: Device, index: number): string {
+  const parts: string[] = [];
+  if (device.identifiers?.vendor_id) {
+    parts.push(`Vendor ${device.identifiers.vendor_id}`);
+  }
+  if (device.identifiers?.product_id) {
+    parts.push(`Product ${device.identifiers.product_id}`);
+  }
+  if (device.identifiers?.is_keyboard) {
+    parts.push('Keyboard');
+  }
+  if (device.identifiers?.is_pointing_device) {
+    parts.push('Pointing device');
+  }
+
+  if (parts.length === 0) {
+    return `Device ${index + 1}`;
+  }
+
+  return `Device ${index + 1} • ${parts.join(' • ')}`;
+}
+
+export function formatTargetSummary(entry: NormalizedMappingEntry): string {
+  if (entry.toTargets.length === 0) {
+    return 'No key output';
+  }
+
+  return entry.toTargets
+    .slice(0, 3)
+    .map((target) => {
+      const mods =
+        target.modifiers.length > 0 ? `${target.modifiers.join(' + ')} + ` : '';
+      return `${mods}${getKeyLabel(target.key)}`;
+    })
+    .join(', ');
+}


### PR DESCRIPTION
Add a visual keyboard preview in Export so users can inspect all mappings by key and edit mapping JSON inline. This improves export-time review and makes correcting mapping issues faster without leaving the preview flow.